### PR TITLE
Ensured response object isnt reinstantiated when it already was of type rest

### DIFF
--- a/Controller/Front.php
+++ b/Controller/Front.php
@@ -87,7 +87,11 @@ class Glitch_Controller_Front extends Zend_Controller_Front
                 );
 
                 $this->setRequest($request);
-                $response = new Glitch_Controller_Response_Rest();
+                if (! $response instanceof Glitch_Controller_Response_Rest) {
+                    $response = new Glitch_Controller_Response_Rest();
+                }
+
+                $this->setResponse($response);
             }
         }
 

--- a/Controller/Request/RestTestCase.php
+++ b/Controller/Request/RestTestCase.php
@@ -39,4 +39,26 @@ class Glitch_Controller_Request_RestTestCase
     public function getHeaders() {
         return $this->_headers;
     }
+
+    /**
+     * Set raw POST body
+     *
+     * @param  string $content
+     * @return Zend_Controller_Request_HttpTestCase
+     */
+    public function setRawBody($content)
+    {
+        $this->_rawBody = (string) $content;
+        return $this;
+    }
+
+    /**
+     * Get RAW POST body
+     *
+     * @return string|null
+     */
+    public function getRawBody()
+    {
+        return $this->_rawBody;
+    }
 }

--- a/Controller/Response/RestTestCase.php
+++ b/Controller/Response/RestTestCase.php
@@ -3,5 +3,13 @@
 class Glitch_Controller_Response_RestTestCase
     extends Glitch_Controller_Response_Rest
 {
-   
+    public function outputBody()
+    {
+        $fullContent = '';
+        foreach ($this->_body as $content) {
+            $fullContent .= $content;
+        }
+
+        return $fullContent;
+    }
 }

--- a/Test/PHPUnit/RestControllerTestCase.php
+++ b/Test/PHPUnit/RestControllerTestCase.php
@@ -27,6 +27,7 @@ abstract class Glitch_Test_PHPUnit_RestControllerTestCase
             // require_once 'Zend/Controller/Request/HttpTestCase.php';
             $this->_request = new Glitch_Controller_Request_RestTestCase;
         }
+
         return $this->_request;
     }
 
@@ -41,6 +42,7 @@ abstract class Glitch_Test_PHPUnit_RestControllerTestCase
             // require_once 'Zend/Controller/Response/HttpTestCase.php';
             $this->_response = new Glitch_Controller_Response_RestTestCase;
         }
+
         return $this->_response;
     }
 
@@ -69,7 +71,11 @@ abstract class Glitch_Test_PHPUnit_RestControllerTestCase
 
         // Set dispatch data
         if ($postData != null) {
-            $this->_request->setPost($postData);
+            if(is_string($postData)) {
+                $this->_request->setRawBody($postData);
+            } else {
+                $this->_request->setPost($postData);
+            }
         }
 
         $this->_request->setMethod($requestMethod);
@@ -114,7 +120,7 @@ abstract class Glitch_Test_PHPUnit_RestControllerTestCase
              ->throwExceptions(false)
              ->returnResponse(true);
 
-        return $this->frontController->dispatch();
+        return $this->frontController->dispatch($request, $this->getResponse());
     }
 
     /**


### PR DESCRIPTION
Ensured response object isnt reinstantiated when it already was of type rest
