### PR TITLE
Removed var_dump in Form Element Number

### DIFF
--- a/Form/Element/Text/Number.php
+++ b/Form/Element/Text/Number.php
@@ -28,7 +28,6 @@ class Glitch_Form_Element_Text_Number extends Glitch_Form_Element_Text
             {
                 $validator = 'LessThan';
             }
-            var_dump($validatorOpts);
             if (null !== $validator)
             {
                 $this->addValidator($validator, false, $validatorOpts);


### PR DESCRIPTION
In the Form element number (text) a var_dump was not removed.
