### PR TITLE
Experiment: Set correct type in constructor

### DIFF
--- a/Form/Element/Text/Date.php
+++ b/Form/Element/Text/Date.php
@@ -2,5 +2,26 @@
 
 class Glitch_Form_Element_Text_Date extends Glitch_Form_Element_Text
 {
-
+    
+    public function __construct($spec, $options = null)
+    {
+        if ($spec instanceof Zend_Config)
+        {
+            $spec->type = parent::FIELD_DATE;
+        }
+        else
+        {
+            if (null === $options)
+            {
+                $options = array();
+            }
+            if (is_array($options))
+            {
+                $options['type'] = parent::FIELD_DATE;
+            }
+        }
+        
+        parent::__construct($spec, $options);
+    }
+    
 }


### PR DESCRIPTION
Based on [this discussion](http://www.enrise.com/2010/12/html5-zend-framework-form-elements/#comment-2217) this is a prototype for Glitch_Form_Element_Text_Date.

Currently, even if you create an instance of this class and name it anything but `date`, you have to manually set the type of the element.
This adds a new constructor which sets the type if this has not been done in `$spec` or `$options`.

If this is an acceptable solution I will update the other element types accordingly.
