### PR TITLE
added support for the testing-pullrequests environment

### DIFF
--- a/Application/Resource/Router.php
+++ b/Application/Resource/Router.php
@@ -73,7 +73,11 @@ class Glitch_Application_Resource_Router extends Zend_Application_Resource_Route
             // Don't instantiate a URL rewriter in CLI mode
             if ( ($router = $front->getRouter()) != null) {
                 if ($this->_getPhpSapi() == 'cli' &&
-                    $this->_getApplicationEnvironment() != 'testing')
+                    (
+                        $this->_getApplicationEnvironment() != 'testing' &&
+                        $this->_getApplicationEnvironment() != 'testing-pullrequests'
+                    )
+                   )
                 {
                     $front->setRouter(($router = new Glitch_Controller_Router_Cli()));
                 } elseif ( ! ($front instanceof Glitch_Controller_Front &&

--- a/Config/Ini.php
+++ b/Config/Ini.php
@@ -123,7 +123,7 @@ class Glitch_Config_Ini
         );
 
         $backend = 'BlackHole';
-        if(GLITCH_APP_ENV != 'testing' && GLITCH_APP_ENV != 'development') {
+        if(GLITCH_APP_ENV != 'testing' && GLITCH_APP_ENV != 'testing-pullrequests' && GLITCH_APP_ENV != 'development') {
             if (function_exists('zend_shm_cache_store'))
             {
                 $backend = 'ZendServer_ShMem';
@@ -188,7 +188,7 @@ class Glitch_Config_Ini
             $ini->merge(new Zend_Config_Ini($configFile, $section));
         }
 
-    if ('testing' != $section) {
+    if ('testing' != $section && 'testing-pullrequests' != $section) {
             $ini->setReadOnly();
     }
 

--- a/Console/Getopt.php
+++ b/Console/Getopt.php
@@ -26,7 +26,7 @@ class Glitch_Console_Getopt
 
     public static function reset()
     {
-        if(GLITCH_APP_ENV != 'testing') {
+        if(GLITCH_APP_ENV != 'testing' && GLITCH_APP_ENV != 'testing-pullrequests') {
             trigger_error(
                 'Glitch_Console_Getopt::reset() should only be called in testing mode',
                 E_USER_NOTICE


### PR DESCRIPTION
Als onderdeel van https://enrise.atlassian.net/browse/WGNRBKLG-1000 ondersteuning toegevoegd voor de testing-pullrequests environment
