### PR TITLE
Improve how log filters are created

### DIFF
--- a/Application/Resource/Log.php
+++ b/Application/Resource/Log.php
@@ -133,7 +133,7 @@ class Glitch_Application_Resource_Log
                 // @todo (unti)test
                 foreach($option['filters'] as $filterOptions) {
                     $filterClass = $this->_getActorClassName('Filter', $filterOptions['name']);
-                    $filter = new $filterClass($filterOptions['options']);
+                    $filter = $filterClass::factory($filterOptions['options']);
                     $writer->addFilter($filter);
                 }
             }


### PR DESCRIPTION
`Zend_Log_Filter_`'s do not accept a config array of options to build the object, but `factory()` does.
