### PR TITLE
prevent warning errors when autoloading files using include_once

### DIFF
--- a/Loader/Autoloader.php
+++ b/Loader/Autoloader.php
@@ -86,7 +86,7 @@ class Glitch_Loader_Autoloader implements Zend_Loader_Autoloader_Interface
      * Autoload classes for all paths
      *
      * @param string $class
-     * @return void
+     * @return bool
      */
     protected function fallbackAutoload($class)
     {

--- a/Loader/Autoloader.php
+++ b/Loader/Autoloader.php
@@ -57,8 +57,11 @@ class Glitch_Loader_Autoloader implements Zend_Loader_Autoloader_Interface
     {
         $filename = $this->getFileNameFromClassName($class);
 
-        // Don't use require_once: halts execution instantly when file is not found
-        $isLoaded = include_once $filename;
+        $isLoaded = false;
+
+        if (file_exists($filename)) {
+            $isLoaded = include_once $filename;
+        }
 
         if (!class_exists($class, false) && !interface_exists($class, false)) {
             $isLoaded = $this->fallbackAutoload($class);


### PR DESCRIPTION
Newer versions of phpunit (I think 4 and above) come with some sort of [blacklist](https://github.com/sebastianbergmann/phpunit/blob/master/src/Util/Blacklist.php) which attempts to load several classes. This gave me issues because the glitch lib autoloader throws warnings if a file is not found when using the `include_once` statement.

I dont know if this is a good idea, but I've wrapped the `include_once` statement into a `file_exists` statement which will mute the warnings. Resulting in:

- phpunit works again
- All un-resolvable files wont have proper php warnings or stack traces?

I've tested this, and in my case of a missing class it will now simply fatal error. But i don't think i have enough knowledge to determine the impact on other use cases. hence the PR :smile:  
